### PR TITLE
Remove `project` field from `.hasura/context.yaml`

### DIFF
--- a/.hasura/context.yaml
+++ b/.hasura/context.yaml
@@ -4,7 +4,6 @@ definition:
   current: default
   contexts:
     default:
-      project: csv-files
       supergraph: ../supergraph.yaml
       subgraph: ../app/subgraph.yaml
       localEnvFile: ../.env

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ ddn connector introspect csv
 Based on the dataset imported, a SQL schema would be generated. Let's track all the models to get started quickly.
 
 ```bash copy
-ddn model add huggingface "*"
+ddn model add csv "*"
 ```
 
 ## Build your PromptQL app


### PR DESCRIPTION
I was following the `README.md` and trying to build the connector with my `.csv` file.
I kept getting the following error with `ddn project init` command:
```
ERR Project already set as "csv-files" in the context
```

After searching the repo I found out that the project field was already specified but it should be set automatically after this command.

This PR removes this line and makes it possible to build the connector